### PR TITLE
Restructure and expand contributing docs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -136,3 +136,8 @@ no = 'Sorry to hear that. Please <a href="https://github.com/genebean/piweatherr
 	url = "https://github.com/genebean/PiWeatherRock"
 	icon = "fab fa-github"
         desc = "PiWeatherRock development takes place here!"
+[[params.links.developer]]
+	name = "Help"
+	url = "../docs/proposing-changes"
+	icon = "fas fa-book"
+        desc = "Learn how to submit modifications to PiWeatherRock"

--- a/content/en/docs/Contribution guidelines/_index.md
+++ b/content/en/docs/Contribution guidelines/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "Contribution Guidelines"
-linkTitle: "Contribution Guidelines"
+title: "Contribution guidelines"
+linkTitle: "Contributing"
 weight: 10
 description: >
   How to contribute to the docs
@@ -18,56 +18,9 @@ All submissions, including submissions by project members, must come via a GitHu
 pull requests. Consult GitHub's [Proposing changes to your work with pull requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/proposing-changes-to-your-work-with-pull-requests)
 docs for more information.
 
-## Quick start with Netlify
-
-Here's a quick guide to updating the docs. It assumes you're familiar with the
-GitHub workflow and you're happy to use the automated preview of your doc
-updates:
-
-1. Fork the [PiWeatherRock Docs repo](https://github.com/genebean/piweatherrock-docs) on GitHub.
-2. Create a new branch for your work
-3. Make your changes and send a pull request (PR).
-4. If you're not yet ready for a review, add "WIP" to the PR name to indicate
-   it's a work in progress. (**Don't** add the Hugo property
-   "draft = true" to the page front matter, because that prevents the
-   auto-deployment of the content preview described in the next point.)
-5. Wait for the automated PR workflow to do some checks. When it's ready,
-   you should see a comment like this: **deploy/netlify — Deploy preview ready!**
-6. Click **Details** to the right of "Deploy preview ready" to see a preview
-   of your updates.
-7. Continue updating your doc and pushing your changes until you're happy with
-   the content.
-8. When you're ready for a review, add a comment to the PR, and remove any
-   "WIP" markers.
-
-## Updating a single page
-
-If you've just spotted something you'd like to change while using the docs, Docsy has a shortcut for you:
-
-1. Click **Edit this page** in the top right hand corner of the page.
-2. If you don't already have an up to date fork of the project repo, you are prompted to get one - click **Fork this repository and propose changes** or **Update your Fork** to get an up to date version of the project to edit. The appropriate page in your fork is displayed in edit mode.
-3. Follow the rest of the [Quick start with Netlify](#quick-start-with-netlify) process above to make, preview, and propose your changes.
-
-## Previewing your changes locally
-
-If you want to run your own local Hugo server to preview your changes as you work:
-
-1. Follow the instructions in Docsy's [Getting started](https://www.docsy.dev/docs/getting-started/) guide to install Hugo and any other tools you need. You'll need at least **Hugo version 0.63.1** (we recommend using the most recent available version), and it must be the **extended** version, which supports SCSS (the version installed by Homebrew on macOS is the right version).
-2. Fork the [PiWeatherRock Docs repo](https://github.com/genebean/piweatherrock-docs) repo as talked about above and then create a local copy using [`git clone --recurse-submodules`](https://www.git-scm.com/docs/git-clone#Documentation/git-clone.txt---recurse-submodulesltpathspec). Be sure to use `--recurse-submodules` or you won’t pull down some of the code you need to generate a working site.
-
-    ```bash
-    git clone --recurse-submodules --depth 1 \
-    https://github.com/<your username>/piweatherrock-docs.git
-    ```
-
-3. Run `hugo server` from inside the piweatherrock-docs folder. By default your site will be available at http://localhost:1313/. Now that you're serving your site locally, Hugo will watch for changes to the content and automatically refresh your site.
-4. Continue with the usual GitHub workflow described above to edit files, commit them, push the changes up to your fork, and create a pull request.
-
-## Creating an issue
-
-If you've found a problem in the docs, but you're not sure how to fix it yourself, please create an issue in the [PiWeatherRock Docs repo](https://github.com/genebean/piweatherrock-docs/issues). You can also create an issue about a specific page by clicking the **Create Issue** button in the top right hand corner of the page.
-
 ## Useful resources
+
+Below are a few pieces of reference material:
 
 * [Docsy user guide](https://www.docsy.dev/docs/): All about Docsy, including how it manages navigation, look and feel, and multi-language support.
 * [Hugo documentation](https://gohugo.io/documentation/): Comprehensive reference for Hugo.

--- a/content/en/docs/Contribution guidelines/creating-an-issue.md
+++ b/content/en/docs/Contribution guidelines/creating-an-issue.md
@@ -1,0 +1,9 @@
+---
+title: "Creating an issue"
+linkTitle: "Creating an issue"
+weight: 40
+description: >
+  How to report a problem or suggestion
+---
+
+If you've found a problem in the docs, but you're not sure how to fix it yourself, please create an issue in the [PiWeatherRock Docs repo](https://github.com/genebean/piweatherrock-docs/issues). You can also create an issue about a specific page by clicking the **Create Issue** button in the top right hand corner of the page (this link only shows in the destkop version of the site).

--- a/content/en/docs/Contribution guidelines/preview-locally.md
+++ b/content/en/docs/Contribution guidelines/preview-locally.md
@@ -1,0 +1,20 @@
+---
+title: "Previewing your changes locally"
+linkTitle: "Preview locally"
+weight: 30
+description: >
+  How to run your own local Hugo server to preview your changes
+---
+
+If you want to run your own local Hugo server to preview your changes as you work:
+
+1. Follow the instructions in Docsy's [Getting started](https://www.docsy.dev/docs/getting-started/) guide to install Hugo and any other tools you need. You'll need at least **Hugo version 0.63.1** (we recommend using the most recent available version), and it must be the **extended** version, which supports SCSS (the version installed by Homebrew on macOS is the right version).
+2. Fork the [PiWeatherRock Docs repo](https://github.com/genebean/piweatherrock-docs) repo as talked about above and then create a local copy using [`git clone --recurse-submodules`](https://www.git-scm.com/docs/git-clone#Documentation/git-clone.txt---recurse-submodulesltpathspec). Be sure to use `--recurse-submodules` or you won’t pull down some of the code you need to generate a working site.
+
+    ```bash
+    git clone --recurse-submodules --depth 1 \
+    https://github.com/<your username>/piweatherrock-docs.git
+    ```
+
+3. Run `hugo server` from inside the piweatherrock-docs folder. By default your site will be available at http://localhost:1313/. Now that you're serving your site locally, Hugo will watch for changes to the content and automatically refresh your site.
+4. Continue with the usual GitHub workflow described above to edit files, commit them, push the changes up to your fork, and create a pull request.

--- a/content/en/docs/Contribution guidelines/quick-start.md
+++ b/content/en/docs/Contribution guidelines/quick-start.md
@@ -1,0 +1,27 @@
+---
+title: "Quick start"
+linkTitle: "Quick start"
+weight: 10
+description: >
+  A quick guide to updating the docs when you already know GitHub
+---
+
+Here's a quick guide to updating the docs. It assumes you're familiar with the
+GitHub workflow and you're happy to use the automated preview of your doc
+updates:
+
+1. Fork the [PiWeatherRock Docs repo](https://github.com/genebean/piweatherrock-docs) on GitHub.
+2. Create a new branch for your work
+3. Make your changes and send a pull request (PR).
+4. If you're not yet ready for a review, add "WIP" to the PR name to indicate
+   it's a work in progress. (**Don't** add the Hugo property
+   "draft = true" to the page front matter, because that prevents the
+   auto-deployment of the content preview described in the next point.)
+5. Wait for the automated PR workflow to do some checks. When it's ready,
+   you should see a comment like this: **deploy/netlify — Deploy preview ready!**
+6. Click **Details** to the right of "Deploy preview ready" to see a preview
+   of your updates.
+7. Continue updating your doc and pushing your changes until you're happy with
+   the content.
+8. When you're ready for a review, add a comment to the PR, and remove any
+   "WIP" markers.

--- a/content/en/docs/Contribution guidelines/update-a-page.md
+++ b/content/en/docs/Contribution guidelines/update-a-page.md
@@ -1,0 +1,15 @@
+---
+title: "Updating a single page"
+linkTitle: "Update a page"
+weight: 20
+description: >
+  Quick edits from the desktop view
+---
+
+If you've just spotted something you'd like to change while using the docs, Docsy has a shortcut for you:
+
+> Note: this currently only works from the desktop version of the site due to flaw in the theme. I am working to resolve this.
+
+1. Click **Edit this page** in the top right hand corner of the page.
+2. If you don't already have an up to date fork of the project repo, you are prompted to get one - click **Fork this repository and propose changes** or **Update your Fork** to get an up to date version of the project to edit. The appropriate page in your fork is displayed in edit mode.
+3. Follow the rest of the [Quick start](../quick-start) process to make, preview, and propose your changes.

--- a/content/en/docs/Proposing changes/_index.md
+++ b/content/en/docs/Proposing changes/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Proposing changes to PiWeatherRock"
+linkTitle: "Proposing changes"
+weight: 6
+description: >
+  A quick guide on sharing your modified version of PiWeatherRock
+---
+
+Got an idea for how to make PiWeatherRock better? AWESOME! Just like with these docs, suggested code should be submitted
+via a GitHub pull requests. Below is a quick guide on how to share your modifications. It assumes that you want to share changes you have made to `weather.py`. If you actually want to share changes to some other file the same general process should work so long as you adjust steps 2 and 4 accordingly.
+
+> Caution: please do not post your API key for Dark Sky or any other sensitive information.
+
+1. Go to the [PiWeatherRock GitHub page](https://github.com/genebean/PiWeatherRock)
+2. Click on `weather.py` to view its code
+   1. Much of what comes next is adapted from GitHub's [Editing files in another user's repository](https://help.github.com/en/github/managing-files-in-a-repository/editing-files-in-another-users-repository) docs.
+3. Just above the code there is a pencil icon on the right side that says "Edit this file" when you mouse over it. Click the pencil.
+4. Back on your computer or Pi, open your modified version of `weather.py` in a text editor and copy everything in it.
+5. Return to the edit page from step 3 and paste your code. This should replace everything with what you copied from your modified version.
+6. Scroll to the bottom. In the small box below the editor, enter a short meaningful description of what your change is.
+7. In the large box add any additional information that will provide more context about what your changes are.
+8. Just below the big box is a place where you can choose which email address will be shown as the author of your changes.
+9. Next, click the green button that says "Propose file change"
+10. In the small field at the top enter a description of your change (this may be the same as in step 6)
+11. In the large field enter any additional information or context that will help me and others understand what you are proposing.
+12. If you are proposing visual changes then please also paste in a screenshot or photo that shows your modifications in action.
+13. Finally, click the green "Create Pull Request" button to submit your suggestion.
+
+🎉 Congratulations! You are now well on your way to being a contributor to this project. Keep an eye out for emails from GitHub as myself or others will likely provide feedback on your suggestions. Also feel free to reach out on [Gitter](https://gitter.im/PiWeatherRock/community) to chat about this process.

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -1,6 +1,5 @@
-
 ---
-title: "Welcome to PiWeatherRock"
+title: 'Welcome to PiWeatherRock'
 linkTitle: "Documentation"
 weight: 20
 menu:


### PR DESCRIPTION
This breaks "Contributing Guidelines" into multiple pages and adds a section for contributing to PiWeatherRock itself.